### PR TITLE
Fixes modal tab trapping not working

### DIFF
--- a/components/modal/modal.jsx
+++ b/components/modal/modal.jsx
@@ -35,11 +35,9 @@ class Modal extends React.Component {
     this.modal.removeEventListener("keyup", this.handleEscPress);
   }
 
-  unsafe_componentWillReceiveProps(nextProps) {
-    if (nextProps.isVisible !== this.props.isVisible) {
-      if (nextProps.isVisible) {
-        this.onAfterShowModal();
-      }
+  componentDidUpdate(prevProps) {
+    if (this.props.isVisible !== prevProps.isVisible && this.props.isVisible) {
+      this.onAfterShowModal();
     }
   }
 

--- a/components/modal/tab-trapper.jsx
+++ b/components/modal/tab-trapper.jsx
@@ -14,12 +14,32 @@ class TabTrapper extends React.Component {
     shiftKeyIsPressed: false
   };
 
+  previouslyFocusedElement = null;
+
   componentDidMount() {
     this.container.addEventListener("keydown", this.onKeyDown);
   }
 
   componentWillUnmount() {
     this.container.removeEventListener("keydown", this.onKeyDown);
+
+    if (this.previouslyFocusedElement) {
+      this.previouslyFocusedElement.focus();
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (!prevProps.isActive && this.props.isActive) {
+      this.previouslyFocusedElement = document.activeElement;
+    }
+
+    if (
+      prevProps.isActive &&
+      !this.props.isActive &&
+      this.previouslyFocusedElement
+    ) {
+      this.previouslyFocusedElement.focus();
+    }
   }
 
   onKeyDown = e => {


### PR DESCRIPTION
`Modal` had a typo in `UNSAFE_componentWillReceiveProps` which caused tab trapping never to be executed.

This PR refactors this lifecycle method to use `componentDidUpdate` instead, which fixes the issue.

Edit: Also adds logic to set focus back to whatever was in focus before the modal was shown when closing the modal