### PR TITLE
Refactor: Simplifies modal component

### DIFF
--- a/components/modal/modal.jsx
+++ b/components/modal/modal.jsx
@@ -8,31 +8,26 @@ import TabTrapper from "./tab-trapper";
 
 class Modal extends React.Component {
   static propTypes = {
-    children: PropTypes.oneOfType([
-      PropTypes.node,
-      PropTypes.arrayOf(PropTypes.node)
-    ]).isRequired,
-    closeButtonText: PropTypes.string,
+    children: PropTypes.node.isRequired,
     isVisible: PropTypes.bool,
-    onCloseClick: PropTypes.func.isRequired // will be triggered by click on close button, modal background or by pressing the esc key
+    hide: PropTypes.func.isRequired // will be triggered by click on close button, modal background or by pressing the esc key
   };
 
-  static defaultProps = {
-    closeButtonText: "Lukk"
+  state = {
+    fitsOnScreen: false,
+    contentHeight: 0
   };
-
-  state = {};
 
   componentDidMount() {
-    this.modal.addEventListener("keyup", this.handleEscPress);
+    window.addEventListener("keyup", this.handleEscPress);
 
     this.setState({
-      fitsOnScreen: this.modal.offsetHeight < window.innerHeight
+      fitsOnScreen: this.modal.scrollHeight <= window.innerHeight
     });
   }
 
   componentWillUnmount() {
-    this.modal.removeEventListener("keyup", this.handleEscPress);
+    window.removeEventListener("keyup", this.handleEscPress);
   }
 
   componentDidUpdate(prevProps) {
@@ -45,22 +40,22 @@ class Modal extends React.Component {
     // Wait one frame before focusing
     requestAnimationFrame(() => {
       this.modal.focus();
-      this.modalWrapper.scrollTop = 0;
+      this.modal.scrollTop = 0;
     });
 
     this.setState(
       {
-        fitsOnScreen: this.modal.offsetHeight < window.innerHeight
+        fitsOnScreen: this.modal.scrollHeight <= window.innerHeight
       },
       () => {
-        this.setState({ contentHeight: this.modalWrapper.scrollHeight });
+        this.setState({ contentHeight: this.modal.scrollHeight });
       }
     );
   };
 
   handleEscPress = e => {
     if (e.which === 27) {
-      this.props.onCloseClick();
+      this.props.hide();
     }
   };
 
@@ -75,7 +70,8 @@ class Modal extends React.Component {
               "is-visible": this.props.isVisible,
               "fits-on-screen": this.state.fitsOnScreen
             })}
-            ref={d => (this.modalWrapper = d)}
+            ref={div => (this.modal = div)}
+            tabIndex={-1}
             {...ariaProps}
           >
             <div
@@ -83,24 +79,12 @@ class Modal extends React.Component {
               style={{
                 minHeight: this.state.contentHeight
               }}
-              onClick={this.props.onCloseClick}
+              onClick={this.props.hide}
             />
 
-            <div
-              className="modal-content"
-              ref={d => (this.modal = d)}
-              tabIndex={-1}
-            >
-              <TabTrapper isActive={this.props.isVisible}>
-                {this.props.children}
-                <button
-                  className="modal-close"
-                  onClick={this.props.onCloseClick}
-                >
-                  {this.props.closeButtonText}
-                </button>
-              </TabTrapper>
-            </div>
+            <TabTrapper isActive={this.props.isVisible}>
+              {this.props.children}
+            </TabTrapper>
           </div>,
           bodyElement
         );

--- a/components/modal/modal.jsx
+++ b/components/modal/modal.jsx
@@ -10,7 +10,7 @@ class Modal extends React.Component {
   static propTypes = {
     children: PropTypes.node.isRequired,
     isVisible: PropTypes.bool,
-    hide: PropTypes.func.isRequired // will be triggered by click on close button, modal background or by pressing the esc key
+    hide: PropTypes.func.isRequired // will be triggered by click on the modal background or by pressing the esc key
   };
 
   state = {

--- a/components/modal/modal.scss
+++ b/components/modal/modal.scss
@@ -32,26 +32,3 @@
   left: 0;
   background-color: rgba(black, 0.2);
 }
-
-.modal-content {
-  width: 95%;
-  max-width: 600px;
-  margin: 0 auto;
-  position: relative;
-  background-color: white;
-  overflow: hidden;
-  transform: scale(0.9);
-  will-change: transform;
-  transition: transform 0.5s cubic-bezier(0.3, 0.75, 0.3, 1);
-  overflow: hidden;
-
-  .modal.is-visible & {
-    transform: none;
-  }
-}
-
-.modal-close {
-  position: absolute;
-  top: 0;
-  right: 0;
-}

--- a/components/modal/tab-trapper.jsx
+++ b/components/modal/tab-trapper.jsx
@@ -3,10 +3,7 @@ import PropTypes from "prop-types";
 
 class TabTrapper extends React.Component {
   static propTypes = {
-    children: PropTypes.oneOfType([
-      PropTypes.node,
-      PropTypes.arrayOf(PropTypes.node)
-    ]),
+    children: PropTypes.node,
     isActive: PropTypes.bool
   };
 
@@ -17,11 +14,11 @@ class TabTrapper extends React.Component {
   previouslyFocusedElement = null;
 
   componentDidMount() {
-    this.container.addEventListener("keydown", this.onKeyDown);
+    window.addEventListener("keydown", this.onKeyDown);
   }
 
   componentWillUnmount() {
-    this.container.removeEventListener("keydown", this.onKeyDown);
+    window.removeEventListener("keydown", this.onKeyDown);
 
     if (this.previouslyFocusedElement) {
       this.previouslyFocusedElement.focus();
@@ -46,31 +43,29 @@ class TabTrapper extends React.Component {
     this.setState({ shiftKeyIsPressed: e.shiftKey });
   };
 
-  trapFirst = () => {
+  jumpToEnd = () => {
     this.afterWrapper.focus();
   };
 
-  trapLast = () => {
+  jumpToStart = () => {
     this.beforeWrapper.focus();
   };
 
-  getButtonStyle = () => {
-    return {
-      position: "absolute",
-      width: 0,
-      height: 0,
-      left: "-999em",
-      overflow: "hidden"
-    };
+  buttonStyle = {
+    position: "absolute",
+    width: 0,
+    height: 0,
+    left: "-999em",
+    overflow: "hidden"
   };
 
   render() {
     return (
-      <div ref={div => (this.container = div)}>
+      <React.Fragment>
         {this.props.isActive && (
           <button
-            onFocus={this.trapFirst}
-            style={this.getButtonStyle()}
+            onFocus={this.jumpToEnd}
+            style={this.buttonStyle}
             disabled={!this.state.shiftKeyIsPressed}
           />
         )}
@@ -80,9 +75,9 @@ class TabTrapper extends React.Component {
 
         <div ref={div => (this.afterWrapper = div)} tabIndex={-1} />
         {this.props.isActive && (
-          <button onFocus={this.trapLast} style={this.getButtonStyle()} />
+          <button onFocus={this.jumpToStart} style={this.buttonStyle} />
         )}
-      </div>
+      </React.Fragment>
     );
   }
 }

--- a/demos/source/mockup/pages/modal/modal.jsx
+++ b/demos/source/mockup/pages/modal/modal.jsx
@@ -5,14 +5,18 @@ import Layout from "../../layout";
 import Modal from "components/modal";
 require("components/modal/modal.scss");
 
+const modalStyle = {
+  position: "relative",
+  backgroundColor: "white",
+  width: "90%",
+  maxWidth: 600,
+  margin: "0 auto"
+};
+
 class ModalPage extends React.Component {
   state = {
     modalVisible: false
   };
-
-  componentDidMount() {
-    this.setState({ button: this.button });
-  }
 
   toggleModal = () => {
     this.setState(state => ({
@@ -20,26 +24,21 @@ class ModalPage extends React.Component {
     }));
   };
 
-  onModalClose = () => {
+  hideModal = () => {
     this.setState({ modalVisible: false });
-    this.button.focus();
   };
 
   render() {
     return (
       <Layout>
         <div>
-          <button onClick={this.toggleModal} ref={b => (this.button = b)}>
-            Vis modal
-          </button>
+          <button onClick={this.toggleModal}>Vis modal</button>
 
-          <Modal
-            buttonThatOpened={this.state.button}
-            isVisible={this.state.modalVisible}
-            onCloseClick={this.onModalClose}
-          >
-            <h2>Hallo</h2>
-            <button>test</button>
+          <Modal hide={this.hideModal} isVisible={this.state.modalVisible}>
+            <div style={modalStyle}>
+              <h2>Hallo</h2>
+              <button onClick={this.hideModal}>Lukk</button>
+            </div>
           </Modal>
         </div>
       </Layout>


### PR DESCRIPTION
After using the Modal component in a few projects I felt like it was too hard to work with. There were too many layers of nested divs which made styling a pain.

This PR
- removes the close button (which allowed for removing one wrapper div)
- moves event listeners from refs to `window`, allowing for the removal of the wrapper div in `tab-trapper`
- renames `onCloseClick` -> `hide` because it was a terrible name
- renames `trapFirst` -> `jumpToEnd` and `trapLast` -> `jumpToStart` because ew